### PR TITLE
Tag nn.Linear for the Linear hub kernel

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3823,6 +3823,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
             register_kernel_mapping_transformers()
 
+            # Make torch.nn.Linear kernelizable so the Hub "Linear" kernel (a tiled matmul that recomputes
+            # in the backward to save activation memory) is swapped in during training. nn.Linear is a
+            # builtin, so it is tagged via replace_kernel_forward_from_hub instead of a decorator.
+            from .integrations import replace_kernel_forward_from_hub
+
+            replace_kernel_forward_from_hub(nn.Linear, "Linear")
+
             if kernel_config is not None:
                 if not isinstance(kernel_config, KernelConfig):
                     raise ValueError(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4714,9 +4714,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             else:
                 kernelize(self, device=Device(type=self.device.type), mode=mode)
 
-            # A linear nested inside an already-kernelized non-Linear layer (e.g. a tiled MLP) would be
-            # tiled twice, since kernelize swaps both. The parent kernel already covers those linears, so
-            # restore their original forward; this also keeps PEFT adapters and hooks on them working.
+            # `kernelize` recurses into submodules, so a linear nested inside an already-kernelized
+            # non-Linear layer (e.g. a tiled MLP) gets kernelized too and is then computed twice, once by
+            # the parent kernel and once on its own. Restore the child's original forward; this also keeps
+            # PEFT adapters and hooks on it working.
             for _, parent in self.named_modules():
                 if getattr(type(parent), "kernel_layer_name", None) in (None, "Linear"):
                     continue

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4714,6 +4714,18 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             else:
                 kernelize(self, device=Device(type=self.device.type), mode=mode)
 
+            # A linear nested inside an already-kernelized non-Linear layer (e.g. a tiled MLP) would be
+            # tiled twice, since kernelize swaps both. The parent kernel already covers those linears, so
+            # restore their original forward; this also keeps PEFT adapters and hooks on them working.
+            for _, parent in self.named_modules():
+                if getattr(type(parent), "kernel_layer_name", None) in (None, "Linear"):
+                    continue
+                for child in parent.modules():
+                    if child is parent or getattr(type(child), "kernel_layer_name", None) != "Linear":
+                        continue
+                    if "forward" in vars(child):
+                        del child.forward
+
             self._use_kernels = True
 
         finally:

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -184,6 +184,24 @@ class TestHubKernels(TestCasePlus):
         self.assert_kernelized_forward_is_the_same(model, self.model_kernelized)
         del model
 
+    def _assert_mlp_linears_match_baseline(self, model):
+        baseline = dict(self.model_not_kernelized.named_modules())
+        nested = [(n, m) for n, m in model.named_modules() if n.endswith((".gate_proj", ".up_proj", ".down_proj"))]
+        self.assertTrue(nested)
+        for name, module in nested:
+            self.assertEqual(module.forward.__code__, baseline[name].forward.__code__)
+
+    def test_nested_mlp_linears_are_not_double_kernelized(self):
+        # nn.Linear is tagged "Linear", so the linears inside an already-kernelized SwiGLU MLP would be
+        # computed twice; they must run the plain nn.Linear forward, before and after a mode switch.
+        model = copy.deepcopy(self.model_not_kernelized)
+        model.use_kernels = True
+        self._assert_mlp_linears_match_baseline(model)
+        model.train()
+        model.eval()
+        self._assert_mlp_linears_match_baseline(model)
+        del model
+
     def test_unkernelize(self):
         model = copy.deepcopy(self.model_kernelized)
 


### PR DESCRIPTION
Stacked on top of #46575 (base is your `propogate-kernels` branch, so the diff is just the two commits).

This wires up the generic `Linear` hub kernel you sketched in the #46575 description. Since `nn.Linear` is a builtin we cannot decorate, so `set_use_kernels` tags it with `replace_kernel_forward_from_hub(nn.Linear, "Linear")`. After that, `kernelize` swaps every `nn.Linear` to the Hub `LigerLinear` (a tiled matmul that recomputes in the backward) in `Mode.TRAINING | Mode.TORCH_COMPILE`.

Second commit handles the nesting you flagged: an MLP kernel (e.g. tiled SwiGLU) calls its own `gate/up/down_proj`, so kernelize swapping both the MLP and those linears would tile twice. After kernelize, we restore the original forward of any `nn.Linear` nested inside an already-kernelized non-Linear layer. kernelize swaps the instance forward, so a `del child.forward` reverts it. Keeping the real module (rather than tiling the matmul in the parent kernel) also preserves PEFT adapters and forward hooks on those projections, which a weight-only path would drop.

Verified locally: the tag sets `nn.Linear.kernel_layer_name = "Linear"`, and the restore loop reverts a nested linear's swapped forward.

Note: the tiled kernel's FSDP2 and DeepSpeed ZeRO-3 fixes landed in kernels-community #1000 (merged, rebuilt on the Hub), verified on 2x H100.
